### PR TITLE
Make crop squares clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,11 @@ There are three types of branches I maintain.
 ##### 02 September 2021 | commit 5b8bf9c8c623623926f0b7ce53096617e3b65504
 * Removed testing code from `Landing.jsx` file.
 * Imported the `useState` hook to `CropSquare.jsx` and set up a state value for a CSS class to be added/removed on click.
-##### 02 September 2021 | commit --
+##### 02 September 2021 | commit 404577e30cba2a92c937bcb7e63bed7d526087c6
 * Attached a function click handler as an `onClick` attribute to each individual crop square.
+##### 02 September 2021 | commit --
+* The click handler on each individual crop square rendered toggles a CSS class on that and only that `<div>` on click.
+* Recorded current thoughts on how to proceed with adding and removing CSS classes for each crop when clicked.
 
 [Back to Top](#top)
 

--- a/README.md
+++ b/README.md
@@ -164,9 +164,11 @@ There are three types of branches I maintain.
 <a id='branch-make-crop-squares-clickable'>
 
 #### BRANCH make-crop-squares-clickable
-##### [DATE] | commit --
+##### 02 September 2021 | commit 5b8bf9c8c623623926f0b7ce53096617e3b65504
 * Removed testing code from `Landing.jsx` file.
 * Imported the `useState` hook to `CropSquare.jsx` and set up a state value for a CSS class to be added/removed on click.
+##### 02 September 2021 | commit --
+* Attached a function click handler as an `onClick` attribute to each individual crop square.
 
 [Back to Top](#top)
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ There are three types of branches I maintain.
 * On GitHub: Merge pull request #3 from mhsmith321/create-calendar-data
 * [Commit Notes](#branch-create-calendar-data)
 * [Summary on GitHub](https://github.com/mhsmith321/Stardew-Valley-Crop-Planner-v1/pull/3)
-##### v 0.1.2.0 | 26 August 2021 | commit bad9404d3be21c5c6067a60a0e67d5dca1e156f5 | Current Version
+##### v 0.1.2.0 | 26 August 2021 | commit bad9404d3be21c5c6067a60a0e67d5dca1e156f5
 * On GitHub: Merge pull request #5 from mhsmith321/create-initial-landing-page
 * [Commit Notes](#branch-create-initial-landing-page)
 * [Summary on GitHub](https://github.com/mhsmith321/Stardew-Valley-Crop-Planner-v1/pull/5)
+##### v 0.1.2.0 | 26 August 2021 | commit 97404ef2a92fdb66c0ba68db3c6279dd9eddeb84 | Current Version
+* On GitHub: Merge pull request #7 from mhsmith321/render-grid-squares 
+* [Commit Notes](#branch-render-grid-squares)
+* [Summary on GitHub](https://github.com/mhsmith321/Stardew-Valley-Crop-Planner-v1/pull/7)
+
 
 #### BRANCH meta-changes
 ##### 26 August 2021 | commit 798ebe92b0847e0b272c5d164e2aa038e26c8745
@@ -119,6 +124,10 @@ There are three types of branches I maintain.
 * Called the two `useState` hooks in `<Landing />` to get boxes down & across in one meta-function.
 ##### 26 August 2021 | commit eb794d135fc5d47c2873ec5efd6ae4b2644a6d13
 * Add comments to `<Landing />` to better section-off code and explain how it works.
+
+<a id='branch-render-grid-squares'>
+
+#### BRANCH render-grid-squares
 ##### 30 August 2021 | commit a85d8e3a07f6b6306d9dfb97476b928672c58e03
 * Create an HTML element to hold the crop grid.
 * Render a grey square on the page, 1rem by 1rem.
@@ -147,10 +156,17 @@ There are three types of branches I maintain.
 * I did a complete refactor of how `CropGrid.jsx` works.
   * JavaScript now lays out a CSS grid in the proper dimensions according to user input.
   * A template generation function inserts a `<div>` into the grid, which the grid then places.
-##### 31 August 2021 | commit --
+##### 31 August 2021 | commit 33385c6fcaddb0e2ec244d4ab7cef1a77df70680
 * Moved JSX for crop grid squares into their own functional component.
 * As many boxes are rendered as the user needs (rows * columns) and assigned one per grid section.
 * Everything started working when I got rid of hooks entirely.  Because all rendering happens after click, I don't need to update anything until the next click which is taken care of inside the `Landing.jsx` file.
+
+<a id='branch-make-crop-squares-clickable'>
+
+#### BRANCH make-crop-squares-clickable
+##### [DATE] | commit --
+* Removed testing code from `Landing.jsx` file.
+* Imported the `useState` hook to `CropSquare.jsx` and set up a state value for a CSS class to be added/removed on click.
 
 [Back to Top](#top)
 

--- a/src/components/CropSquare.css
+++ b/src/components/CropSquare.css
@@ -4,3 +4,7 @@
     margin: 0.4rem;
     background-color: grey;
 }
+
+.red-background {
+    background-color: red !important;
+}

--- a/src/components/CropSquare.jsx
+++ b/src/components/CropSquare.jsx
@@ -1,5 +1,5 @@
 /******* START: IMPORT REACT, HOOKS, AND DONGLES *******/
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 /******* END: IMPORT REACT, HOOKS, AND DONGLES *********/
 
 
@@ -9,12 +9,16 @@ import './CropSquare.css';
 
 
 function CropSquare(props) {
-    const [cropClass, setCropClass] = useState(null);
+    const [cropClass, setCropClass] = useState(false);
+
+    function sayClicked() {
+        console.log('clicked!');
+    }
 
     const {squareNumber} = props;
     const idString = `crop-grid-square-${squareNumber}`;
     return (
-        <div className='crop-grid-square' id={idString} key={idString} />
+        <div className='crop-grid-square' id={idString} key={idString} onClick={() => sayClicked()} />
     );
 }
 

--- a/src/components/CropSquare.jsx
+++ b/src/components/CropSquare.jsx
@@ -1,5 +1,5 @@
 /******* START: IMPORT REACT, HOOKS, AND DONGLES *******/
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 /******* END: IMPORT REACT, HOOKS, AND DONGLES *********/
 
 
@@ -8,17 +8,43 @@ import './CropSquare.css';
 /******* END: IMPORT LOCAL FILES *********/
 
 
+/**     FUTURE PLANS!
+ *          I intend to have a CSS class for every possible crop.  The user will click a crop making that
+ *          the 'active' crop in state, then the click handler remove the current crop class (if one is
+ *          currently applied) and apply the class for the crop currently held in state.  This will get
+ *          tricky as it's not the only className value applied.  There are a few workaround for how I
+ *          might accomplish this.
+ *              1. Use the 'style' attribute to add CSS style from a library directly.  This means holding
+ *                 style data in a store, not in the CSS file, which actually might be easier.  Especially
+ *                 if I render a styled <div>.  But this may be problematic if I need an attribute in the
+ *                 <div> for other identification functions which seems likely.
+ *              2. Remove all CSS classes and re-add 'crop-grid-square' with the specific crop class.
+ *              3. Remove all CSS classes NOT 'crop-grid-square' then add the specific crop class.
+ *              4. Check for every single crop class and remove if present, then add the current crop class
+ *                 being held in state.
+ *              5. Is there a way to use state to hold the current crop class, then combine that into a
+ *                 string with 'crop-grid-square' (space separated) and insert the string as a class?  Might
+ *                 work with useEffect.
+ *          IMPORTANT!
+ *              Whatever I do, I need to be careful about issues with the page looking funny if noticeable
+ *              time passes between one class being stripped and the next being added.  If I iterate through
+ *              all possible classes, make sure the break the loop when a class is found and removed.  Probably
+ *              need to pass the value to a variable outside the loop, terminate the loop, then add and remove
+ *              relevant classes.
+ */
+
+
 function CropSquare(props) {
-    const [cropClass, setCropClass] = useState(false);
-
-    function sayClicked() {
-        console.log('clicked!');
-    }
-
     const {squareNumber} = props;
     const idString = `crop-grid-square-${squareNumber}`;
+
+    function handleClick(event) {
+        const clickedSquare = event.target;
+        clickedSquare.classList.toggle('red-background');
+    }
+
     return (
-        <div className='crop-grid-square' id={idString} key={idString} onClick={() => sayClicked()} />
+        <div className='crop-grid-square' id={idString} key={idString} onClick={event => handleClick(event)} />
     );
 }
 

--- a/src/components/CropSquare.jsx
+++ b/src/components/CropSquare.jsx
@@ -1,5 +1,5 @@
 /******* START: IMPORT REACT, HOOKS, AND DONGLES *******/
-import React from 'react';
+import React, { useState } from 'react';
 /******* END: IMPORT REACT, HOOKS, AND DONGLES *********/
 
 
@@ -9,6 +9,8 @@ import './CropSquare.css';
 
 
 function CropSquare(props) {
+    const [cropClass, setCropClass] = useState(null);
+
     const {squareNumber} = props;
     const idString = `crop-grid-square-${squareNumber}`;
     return (

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -46,8 +46,8 @@ function Landing() {
             <hr />
 
             <div className='flexbox-center-me'>
-                <p>Across: {numberAcross} {typeof numberAcross}</p>
-                <p>Down: {numberDown} {typeof numberDown}</p>
+                <p>Across: {numberAcross}</p>
+                <p>Down: {numberDown}</p>
 
                 <CropGrid numberOfColumns={numberAcross} numberOfRows={numberDown}/>
             </div>


### PR DESCRIPTION
# Complete work on branch make-crop-squares-clickable

* Each rendered crop square has a click handler function which toggles a CSS class on and off.
* There are a number of approaches I might use to insert a class to differentially style the CSS on click which I discussed at length in the file with inline notes.